### PR TITLE
different constructor for CustomEvent (based on the DOM4 spec)

### DIFF
--- a/EventListener.js
+++ b/EventListener.js
@@ -93,17 +93,19 @@ this.Element && Element.prototype.attachEvent && !Element.prototype.addEventList
 		get: function () {
 			var self = this;
 
-			return function CustomEvent(type, canBubble, cancelable, detail) {
+			return function CustomEvent(type, eventInitDict) {
 				var event = self.document.createEventObject(), key;
 
 				event.type = type;
-				event.returnValue = !cancelable;
-				event.cancelBubble = !canBubble;
-
-				for (key in detail) {
-					event[key] = detail[key];
+				for (key in eventInitDict) {
+					if (key == 'cancelable'){
+						event.returnValue = !eventInitDict.cancelable;
+					} else if (key == 'bubbles'){
+						event.cancelBubble = !eventInitDict.bubbles;
+					} else if (key == 'detail'){
+						event.detail = eventInitDict.detail;
+					}
 				}
-
 				return event;
 			};
 		}


### PR DESCRIPTION
Firefox implements like this:
- https://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#interface-customevent
- https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent#Constructor
