### PR TITLE
Add CustomEvent constructor polyfill

### DIFF
--- a/EventListener.js
+++ b/EventListener.js
@@ -127,9 +127,19 @@ this.Element && Element.prototype.attachEvent && !Element.prototype.addEventList
 !this.CustomEvent && (function() {
 	// CustomEvent for browsers which don't natively support the Constructor method
 	window.CustomEvent = function CustomEvent(type, eventInitDict) {
+		var event;
 		eventInitDict = eventInitDict || {bubbles: false, cancelable: false, detail: undefined};
-		var event = document.createEvent('CustomEvent');
-		event.initCustomEvent(type, eventInitDict.bubbles, eventInitDict.cancelable, eventInitDict.detail);
+
+		try {
+			event = document.createEvent('CustomEvent');
+			event.initCustomEvent(type, eventInitDict.bubbles, eventInitDict.cancelable, eventInitDict.detail);
+		} catch (error) {
+			// for browsers which don't support CustomEvent at all, we use a regular event instead
+			event = document.createEvent('Event');
+			event.initEvent(type, eventInitDict.bubbles, eventInitDict.cancelable);
+			event.detail = eventInitDict.detail;
+		}
+
 		return event;
 	};
 })();


### PR DESCRIPTION
This change makes IE9+ and older WebKit and Gecko versions compatible with using `new CustomEvent()`.

One particular case where we needed this was on Android, as versions prior to 4.4 support custom events, but do not support the `CustomEvent` constructor.

The original polyfill was from [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent#Polyfill), but I've attempted to match your code style (and that of the CustomEvent constructor for older IE versions).

Additionally, we've added support for Android 2.x, which doesn't support CustomEvent at all.
